### PR TITLE
Remove supported version info from tutorial

### DIFF
--- a/_integrations/solarwinds.md
+++ b/_integrations/solarwinds.md
@@ -5,10 +5,6 @@ draft: false
 type: System Monitoring
 ---
 
-#### Compatibility
-
-The BigPanda-SolarWinds integration only supports Orion server version 2015.1 or higher. Contact [support@bigpanda.io](mailto:support@bigpanda.io?Subject=SolarWinds%integration%help "contact BigPanda support") with questions about version support.
-
 <!-- section-separator -->
 
 #### Create system user account in SolarWinds

--- a/_integrations/solarwinds.md
+++ b/_integrations/solarwinds.md
@@ -5,8 +5,6 @@ draft: false
 type: System Monitoring
 ---
 
-<!-- section-separator -->
-
 #### Create system user account in SolarWinds
 
 If you already have a user account with system rights, proceed to the next step. If not, create a new account.


### PR DESCRIPTION
@dshush Please review and merge if ok. I removed the supported versions section from the tutorial since we will now maintain this information as part of the permanent documentation.