### PR TITLE
Templated api.bigpanda.io string into WEB_API_BASE_URL parameter 

### DIFF
--- a/_integrations/airbrake.md
+++ b/_integrations/airbrake.md
@@ -12,7 +12,7 @@ For each project in Airbrake:
 * Click the small menu icon on the upper left corner, then navigate to `Project Settings`.
 * From the left menu, select `Integrations`.
 * Select `WebHooks` integration and enter the `Url`:  
-  ```https://api.bigpanda.io/data/integrations/airbrake?$URL_PARAMS```
+  ```$WEB_API_BASE_URL/data/integrations/airbrake?$URL_PARAMS```
 * Keep the `Active` check box selected.
 * Click `Save`.
 

--- a/_integrations/alertsapi-ruby.md
+++ b/_integrations/alertsapi-ruby.md
@@ -23,7 +23,7 @@ Using BigPanda's Alerts API is easy. Start by creating an app key with the form 
 
 The integrated system should call the Alerts API endpoint:
     
-    https://api.bigpanda.io/data/v2/alerts
+    $WEB_API_BASE_URL/data/v2/alerts
     
 
 Use the following HTTP headers:
@@ -66,14 +66,14 @@ Below is an example of a full payload:
  
     curl -XPOST -H "Content-Type: application/json" \
     -H "Authorization: Bearer $TOKEN" \
-    https://api.bigpanda.io/data/v2/alerts \
+    $WEB_API_BASE_URL/data/v2/alerts \
     -d '{ "app_key": "$STREAM_ID", "status": "critical", "host": "production-database-1", "check": "CPU overloaded" }'
 
 The alert should appear in the [BigPanda dashboard](https://a.bigpanda.io) almost instantaniously. Now close the alert by executing: 
 
     curl -XPOST -H "Content-Type: application/json" \
     -H "Authorization: Bearer $TOKEN" \
-    https://api.bigpanda.io/data/v2/alerts \
+    $WEB_API_BASE_URL/data/v2/alerts \
     -d '{ "app_key": "$STREAM_ID", "status": "ok", "host": "production-database-1", "check": "CPU overloaded" }'
     
 <!-- docs-only-start -->

--- a/_integrations/api.md
+++ b/_integrations/api.md
@@ -9,7 +9,7 @@ draft: false
 
 Configure the integrated system to call the Alerts API endpoint:
     
-    https://api.bigpanda.io/data/v2/alerts
+    $WEB_API_BASE_URL/data/v2/alerts
     
 
 Use the following HTTP headers:
@@ -54,12 +54,12 @@ To validate that everything is configured correctly, send a test alert by runnin
  
     curl -XPOST -H "Content-Type: application/json" \
     -H "Authorization: Bearer $TOKEN" \
-    https://api.bigpanda.io/data/v2/alerts \
+    $WEB_API_BASE_URL/data/v2/alerts \
     -d '{ "app_key": "$STREAM_ID", "status": "critical", "host": "production-database-1", "check": "CPU overloaded" }'
 
 The alert should now appear in the [Incidents dashboard](https://a.bigpanda.io). Close the alert by running: 
 
     curl -XPOST -H "Content-Type: application/json" \
     -H "Authorization: Bearer $TOKEN" \
-    https://api.bigpanda.io/data/v2/alerts \
+    $WEB_API_BASE_URL/data/v2/alerts \
     -d '{ "app_key": "$STREAM_ID", "status": "ok", "host": "production-database-1", "check": "CPU overloaded" }'

--- a/_integrations/appdynamicsapi.md
+++ b/_integrations/appdynamicsapi.md
@@ -38,7 +38,7 @@ __Note__: Complete this step only one time per AppDynamics controller.
 6\. In the **Request URL** section:
 
 * For the method, select **POST**.
-* In the **Raw URL** field, enter `https://api.bigpanda.io/data/integrations/appdynamics-webhook?app_key=$STREAM_ID`.
+* In the **Raw URL** field, enter `$WEB_API_BASE_URL/data/integrations/appdynamics-webhook?app_key=$STREAM_ID`.
     
 7\. In the **Custom Request Headers** section, add a header with the following values:
     `Authorization`     `Bearer $TOKEN`

--- a/_integrations/catchpoint.md
+++ b/_integrations/catchpoint.md
@@ -15,7 +15,7 @@ In Catchpoint, go to **Settings > API**.
 
 1\. Under **Alerts API**, add a new endpoint by filling in the fields:
 
-* **Endpoint URL**: `https://api.bigpanda.io/data/integrations/catchpoint?$URL_PARAMS`
+* **Endpoint URL**: `$WEB_API_BASE_URL/data/integrations/catchpoint?$URL_PARAMS`
 * **Status**: **Active**
 
 2\. Under **Format**, click **Select Template > Add new**. A form opens where you can define the template.

--- a/_integrations/datadog.md
+++ b/_integrations/datadog.md
@@ -13,7 +13,7 @@ type: System Monitoring
 2\. In the **New Webhook** form, enter the following information:  
 
 * **Webhook Name:** `BigPanda`
-* **Webhook URL:** `https://api.bigpanda.io/data/integrations/datadog?$URL_PARAMS`
+* **Webhook URL:** `$WEB_API_BASE_URL/data/integrations/datadog?$URL_PARAMS`
 * **Use custom payload:** Select the check box.
 * **Custom payload:** Enter the following JSON payload:
 

--- a/_integrations/deploymentsapi.md
+++ b/_integrations/deploymentsapi.md
@@ -38,7 +38,7 @@ For more information on authentication, start and end event methods, and respons
 
 #### Notify BigPanda When a Deployment Starts
 
-POST your JSON object to `https://api.bigpanda.io/data/events/deployments/start` with the following HTTP headers:
+POST your JSON object to `$WEB_API_BASE_URL/data/events/deployments/start` with the following HTTP headers:
 
     Authorization: Bearer $TOKEN  
     Content-Type: application/json  
@@ -48,7 +48,7 @@ For example, run the following cURL call (with deployment-start.json containing 
     curl -i -X POST -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d @deployment-start.json \
-    "https://api.bigpanda.io/data/events/deployments/start"
+    "$WEB_API_BASE_URL/data/events/deployments/start"
 
 <!-- section-separator -->
 
@@ -81,7 +81,7 @@ Example:
 
 **Note**: Deployments appear as in-progress until you send a matching end notification.
 
-POST your JSON object to `https://api.bigpanda.io/data/events/deployments/end` with the following HTTP headers:
+POST your JSON object to `$WEB_API_BASE_URL/data/events/deployments/end` with the following HTTP headers:
 
     Authorization: Bearer $TOKEN 
     Content-Type: application/json  
@@ -91,6 +91,6 @@ For example, run the following cURL call (with deployment-end.json containing th
     curl -i -X POST -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d @deployment-end.json \
-    "https://api.bigpanda.io/data/events/deployments/end"
+    "$WEB_API_BASE_URL/data/events/deployments/end"
 
 

--- a/_integrations/logicmonitor.md
+++ b/_integrations/logicmonitor.md
@@ -13,7 +13,7 @@ Login to LogicMonitor and go to "Settings" > "Integrations" > "Add" > "Custom HT
 * Select ״Use different URLs or data formats to notify on various alert activity״ (Important for Acknowledge feature)
 * Make sure "New Alerts" and "Cleared" are checked
 * HTTP Method: HTTP Post
-* URL for New and Cleared alerts: `https://api.bigpanda.io/data/integrations/logicmonitor?$URL_PARAMS`
+* URL for New and Cleared alerts: `$WEB_API_BASE_URL/data/integrations/logicmonitor?$URL_PARAMS`
 * Alert Data: choose "raw" and format: "JSON"
 
 Fill payload with:
@@ -55,7 +55,7 @@ Fill payload with:
 * Manage the BigPanda existing integration in logicmonitor
 * Press the plus (+) button
 * Choose the Acknowledged checkbox
-* Webhook URL for Acknowledged alerts: `https://api.bigpanda.io/data/integrations/logicmonitor?$URL_PARAMS&ack=true`
+* Webhook URL for Acknowledged alerts: `$WEB_API_BASE_URL/data/integrations/logicmonitor?$URL_PARAMS&ack=true`
 * Use the same payload given above
 <!-- section-separator -->
 

--- a/_integrations/newrelic-new.md
+++ b/_integrations/newrelic-new.md
@@ -22,7 +22,7 @@ For more information, see the [New Relic Alerts documentation](https://docs.newr
 2\. Fill in the form:
 
 * **Channel name**: `BigPanda`
-* **Base URL**: `https://api.bigpanda.io/data/integrations/newrelic?$URL_PARAMS`
+* **Base URL**: `$WEB_API_BASE_URL/data/integrations/newrelic?$URL_PARAMS`
 
 3\. Click **Add custom payload** and ensure that **JSON** is selected as the payload type.
 

--- a/_integrations/newrelic.md
+++ b/_integrations/newrelic.md
@@ -19,7 +19,7 @@ For more information, see the [legacy alerting system documentation](https://doc
 2\. Fill in the form:
 
 * **Channel Name**: `BigPanda`
-* **Base URL**: `https://api.bigpanda.io/data/integrations/newrelic?$URL_PARAMS`
+* **Base URL**: `$WEB_API_BASE_URL/data/integrations/newrelic?$URL_PARAMS`
 
 3\. Click **Add Custom Payload**, scroll to the bottom and ensure that **JSON** is selected as the payload type.
 

--- a/_integrations/pingdomwebhook.md
+++ b/_integrations/pingdomwebhook.md
@@ -14,7 +14,7 @@ type: Application Monitoring
 
 * **Type**: Select **Webhook**
 * **Name**: `BigPanda Integration`
-* **URL**: `https://api.bigpanda.io/data/integrations/pingdomwebhook?$URL_PARAMS`
+* **URL**: `$WEB_API_BASE_URL/data/integrations/pingdomwebhook?$URL_PARAMS`
 
 Make sure **Active** is selected (default).
 

--- a/_integrations/prtg.md
+++ b/_integrations/prtg.md
@@ -18,7 +18,7 @@ type: System Monitoring
   * In **Notification Name**, enter `BigPanda Notification`.
   * For **NOTIFICATION SUMMARIZATION > Method**, select **Always notify ASAP**.
   * Select the **EXECUTE HTTP ACTION** check box.
-  * In **EXECUTE HTTP ACTION > URL**, enter `https://api.bigpanda.io/data/integrations/prtg?$URL_PARAMS`.
+  * In **EXECUTE HTTP ACTION > URL**, enter `$WEB_API_BASE_URL/data/integrations/prtg?$URL_PARAMS`.
   * In **EXECUTE HTTP ACTION > Postdata**, enter `sensor=%name&status=%status&datetime=%datetime&timezone=%timezone&message=%message&group=%group&device=%device&host=%host&home=%home&prio=%prio&since=%since&linksensor=%linksensor`.
 
   Your Add Notification page should look like this example.  

--- a/_integrations/scout.md
+++ b/_integrations/scout.md
@@ -13,7 +13,7 @@ Login to Scout and in *Account > Notifications* click on *Add Webhook*.
 In the New Webhook form, fill out the following:  
 
 * Webhook Name: `BigPanda`
-* Webhook URL: `https://api.bigpanda.io/data/integrations/scout?$URL_PARAMS`
+* Webhook URL: `$WEB_API_BASE_URL/data/integrations/scout?$URL_PARAMS`
 
 
 <!-- section-separator -->

--- a/_integrations/sentry.md
+++ b/_integrations/sentry.md
@@ -13,7 +13,7 @@ For each project in Sentry:
 * Enable the `WebHooks` plugin (it might be already enabled). You should see a new item under the INTEGRATIONS section.  
 * Click on `Save Changes`.
 * Choose the new item called `WebHooks` and append the URL below to the `Callback URLs` text area:  
-`https://api.bigpanda.io/data/integrations/sentry?$URL_PARAMS`
+`$WEB_API_BASE_URL/data/integrations/sentry?$URL_PARAMS`
 * Click on `Save Changes`
 
 *Note: If you changed the default Rules in Sentry, please consult the relevant FAQ item called __What Rules do I need to configure?__.*

--- a/_integrations/site24x7.md
+++ b/_integrations/site24x7.md
@@ -16,7 +16,7 @@ type: Application Monitoring
 2\. Click **Add Automation**, and add a new action by filling in the fields:
 
 * **Display Name**: `BigPanda`
-* **URL**: `https://api.bigpanda.io/data/integrations/site24x7?$URL_PARAMS`
+* **URL**: `$WEB_API_BASE_URL/data/integrations/site24x7?$URL_PARAMS`
 * **TimeOut**: `30 secs`
 * **HTTP Method**: select **POST**
 * **Send Incident Parameters** and **Post as JSON**: select the check boxes

--- a/_integrations/statuscake.md
+++ b/_integrations/statuscake.md
@@ -12,7 +12,7 @@ Log in to StatusCake.
 Go to [Contact Groups > Create New Contact Group](https://www.statuscake.com/App/ContactGroup.php), and fill out the form as follows:
 
 * **Group Name:** `BigPanda`
-* **Webhook URL** (POST): `https://api.bigpanda.io/data/integrations/statuscake?$URL_PARAMS`
+* **Webhook URL** (POST): `$WEB_API_BASE_URL/data/integrations/statuscake?$URL_PARAMS`
 
 Click on *UPDATE THIS CONTACT GROUP*.
 


### PR DESCRIPTION
When reading documentation in local env or in OD's the url that appears in the documentation refers to api.bigpanda.io which is prod and incorrect in those cases.
Furthermore, in the event that we change our api 'api.bigpanda.io' to something else, all configuration's will break and this commit prevents that.
Related  : bigpandaio/frontier#811 